### PR TITLE
fix: normalize line endings in createSignedPropertiesXml for consiste…

### DIFF
--- a/src/Helpers/InvoiceSignatureBuilder.php
+++ b/src/Helpers/InvoiceSignatureBuilder.php
@@ -207,7 +207,7 @@ class InvoiceSignatureBuilder
             '                                </xades:SignedSignatureProperties>'.PHP_EOL.
             '                            </xades:SignedProperties>';
 
-        return str_replace(
+        $signedPropertiesXml = str_replace(
             [
                 'SIGNING_TIME_PLACEHOLDER',
                 'DIGEST_PLACEHOLDER',
@@ -222,6 +222,9 @@ class InvoiceSignatureBuilder
             ],
             $template
         );
+
+        // Normalize to LF (\n) for consistent XML digest hashing across platforms
+        return str_replace("\r\n", "\n", $signedPropertiesXml);
     }
 
     /**


### PR DESCRIPTION
Fix: normalize line endings for signed-properties-hashing

This fixes an issue where line endings on Windows (\r\n) caused the signed-properties-hashing error,
due to ZATCA expecting purely LF (\n) line endings. The solution always replaces \r\n with \n in the
generated XML.

This is safe across all OS's, as Linux/Mac already use \n.