### PR TITLE
fix: support explicit ZATCA VAT category codes in mappers #19

### DIFF
--- a/src/ClassifiedTaxCategory.php
+++ b/src/ClassifiedTaxCategory.php
@@ -46,19 +46,19 @@ class ClassifiedTaxCategory implements XmlSerializable
      */
     public function getId(): ?string
     {
+        // Explicit ID always has priority (E, O)
         if (! empty($this->id)) {
             return $this->id;
         }
 
+        // Auto-derive only ZATCA-supported cases
         if ($this->getPercent() !== null) {
-            if ($this->getPercent() >= 15) {
+            // Any positive VAT rate in KSA is Standard rated
+            if ($this->getPercent() > 0) {
                 return 'S';
             }
 
-            if ($this->getPercent() >= 6) {
-                return 'AA';
-            }
-
+            // Zero percent without explicit exemption = Zero rated
             return 'Z';
         }
 

--- a/src/Enums/TaxCategoryCode.php
+++ b/src/Enums/TaxCategoryCode.php
@@ -1,0 +1,45 @@
+<?php
+
+namespace Saleh7\Zatca\Enums;
+
+/**
+ * ZATCA VAT Category Codes
+ *
+ * Source:
+ * - UN/ECE 5305
+ * - ZATCA E-Invoicing (KSA) VAT implementation
+ *
+ * These codes define how VAT is applied to a supply.
+ */
+enum TaxCategoryCode: string
+{
+    /**
+     * Standard rated VAT.
+     *
+     * Applied to taxable supplies with a positive VAT rate.
+     * (e.g. 15% in Saudi Arabia)
+     */
+    case Standard = 'S';
+
+    /**
+     * Zero rated VAT.
+     *
+     * VAT rate is 0%, but the supply is still taxable and must be reported to ZATCA.
+     */
+    case Zero = 'Z';
+
+    /**
+     * Exempt from VAT.
+     *
+     * Supply is exempt under VAT law.
+     */
+    case Exempt = 'E';
+
+    /**
+     * Outside scope of VAT.
+     *
+     * Supply is not subject to VAT at all.
+     * (e.g. non-KSA transactions)
+     */
+    case Outside = 'O';
+}

--- a/src/Mappers/InvoiceMapper.php
+++ b/src/Mappers/InvoiceMapper.php
@@ -272,11 +272,17 @@ class InvoiceMapper
             // Check if taxCategories is an array and iterate over it.
             if (isset($allowanceCharge['taxCategories']) && is_array($allowanceCharge['taxCategories'])) {
                 foreach ($allowanceCharge['taxCategories'] as $taxCatData) {
-                    $taxCategories[] = (new TaxCategory)
+                    $taxCategory = (new TaxCategory)
                         ->setPercent($taxCatData['percent'] ?? 15)
                         ->setTaxScheme(
                             (new TaxScheme)->setId($taxCatData['taxScheme']['id'] ?? 'VAT')
                         );
+
+                    if (isset($taxCatData['id'])) {
+                        $taxCategory->setId($taxCatData['id']);
+                    }
+
+                    $taxCategories[] = $taxCategory;
                 }
             }
 
@@ -328,6 +334,7 @@ class InvoiceMapper
 
                 // Build the TaxCategory object using the extracted data.
                 $taxCategory = (new TaxCategory)
+                    ->setId($taxCategoryData['id'] ?? null)
                     ->setPercent($percent)
                     ->setTaxExemptionReasonCode($reasonCode)
                     ->setTaxExemptionReason($reason)

--- a/src/Mappers/ItemMapper.php
+++ b/src/Mappers/ItemMapper.php
@@ -30,20 +30,24 @@ class ItemMapper
      */
     public function map(array $data): Item
     {
-        // Map classified tax category for the item.
-        // if percent 15 or more, ID is S (Standard rate)
-        // if percent 6 to 14.99, ID is AA (Reduced rate)
-        // if percent less than 6, ID is Z (Zero rate)
         $classifiedTax = [];
         if (isset($data['classifiedTaxCategory']) && is_array($data['classifiedTaxCategory'])) {
             foreach ($data['classifiedTaxCategory'] as $tax) {
                 // Map TaxScheme for the item.
-                $taxScheme = (new TaxScheme)
-                    ->setId($tax['taxScheme']['id'] ?? 'VAT');
-                // Create and add a new ClassifiedTaxCategory object to the array.
-                $classifiedTax[] = (new ClassifiedTaxCategory)
+                $taxScheme = (new TaxScheme)->setId($tax['taxScheme']['id'] ?? 'VAT');
+
+                // Create ClassifiedTaxCategory
+                $taxCategory = (new ClassifiedTaxCategory)
                     ->setPercent($tax['percent'] ?? 15)
                     ->setTaxScheme($taxScheme);
+
+                // Allow explicit VAT category code (S, Z, E, O)
+                if (isset($tax['id'])) {
+                    $taxCategory->setId($tax['id']);
+                }
+
+                // Add to list
+                $classifiedTax[] = $taxCategory;
             }
         }
 

--- a/src/TaxCategory.php
+++ b/src/TaxCategory.php
@@ -54,19 +54,19 @@ class TaxCategory implements XmlSerializable
      */
     public function getId(): ?string
     {
+        // Explicit ID always has priority (E, O, custom handling)
         if (! empty($this->id)) {
             return $this->id;
         }
 
+        // Auto-derive only for ZATCA-supported cases
         if ($this->getPercent() !== null) {
-            if ($this->getPercent() >= 15) {
+            // Any positive VAT rate in KSA is Standard rated
+            if ($this->getPercent() > 0) {
                 return 'S';
             }
 
-            if ($this->getPercent() >= 6) {
-                return 'AA';
-            }
-
+            // Zero percent without explicit exemption = Zero rated
             return 'Z';
         }
 

--- a/tests/Mappers/InvoiceMapperTest.php
+++ b/tests/Mappers/InvoiceMapperTest.php
@@ -125,6 +125,7 @@ class InvoiceMapperTest extends TestCase
                         'taxableAmount' => 4,
                         'taxAmount' => 0.6,
                         'taxCategory' => [
+                            'id' => 'S',
                             'percent' => 15,
                             'taxScheme' => [
                                 'id' => 'VAT',


### PR DESCRIPTION
Fix VAT category handling to support explicit ZATCA codes (S, Z, E, O)

Allow explicit tax category IDs to be passed through mappers instead of relying
only on percentage-based inference. This fixes ZATCA warnings when using
Exempt (E) or Outside Scope (O) VAT categories and removes invalid AA handling.

```
'taxTotal' => [
    'taxAmount' => 0.0,
    'subTotals' => [
        [
            'taxableAmount' => 4,
            'taxAmount' => 0.0,
            'taxCategory' => [
                'id' => 'E',          // ← NEW FIELD
                'percent' => 0,
                'reasonCode' => 'VATEX-SA-29',
                'reason' => 'Financial services',
                'taxScheme' => [
                    'id' => 'VAT',
                ],
            ],
        ],
    ],
],
```